### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ with the [Android Studio IDE](https://developer.android.com/sdk/installing/studi
 The original github repository for this codelab is here:
 [https://github.com/GoogleCloudPlatform/endpoints-codelab-android/](https://github.com/GoogleCloudPlatform/endpoints-codelab-android/)
 
-##Table of Contents
+## Table of Contents
 
 - [Android Endpoints "Todo.txt" CodeLab](#user-content-android-endpoints-todotxt-codelab)
     - [Codelab Requirements](#user-content-codelab-requirements)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
